### PR TITLE
Adds a statement to author agreement identifying the BCP as the article's source

### DIFF
--- a/views.py
+++ b/views.py
@@ -20,9 +20,13 @@ from events import logic as event_logic
 @editor_user_required
 def index(request):
     if request.POST:
-        article = models.Article.objects.create(journal=request.journal,
-                                                date_accepted=timezone.now(),
-                                                is_import=True)
+        article = models.Article.objects.create(
+            journal=request.journal,
+            date_accepted=timezone.now(),
+            is_import=True,
+            article_agreement='This record was created using the back '
+                              'content plugin.',
+        )
         return redirect(reverse('bc_article', kwargs={'article_id': article.pk}))
 
     articles = models.Article.objects.filter(journal=request.journal)


### PR DESCRIPTION
When creating a new article via the BCP it will now add a statement to the author agreement field identifying the source of the article as the back content plugin.